### PR TITLE
Feature: Add email user configuration through existing secret

### DIFF
--- a/charts/tenzu-back/Chart.yaml
+++ b/charts/tenzu-back/Chart.yaml
@@ -15,6 +15,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.2.0
 
 home: "https://tenzu.net/docs"

--- a/charts/tenzu-back/README.md
+++ b/charts/tenzu-back/README.md
@@ -38,6 +38,10 @@ A Helm chart to run the API webservices backend and task queue worker of Tenzu
 | email.user | string | `nil` | Used to populate `TENZU_EMAIL__EMAIL_HOST_USER` |
 | email.password | string | `nil` | Used to populate `TENZU_EMAIL__EMAIL_HOST_PASSWORD` |
 | email.supportEmail | string | `nil` | Used to populate `TENZU_SUPPORT_EMAIL` |
+| email.existingSecret | object | `{"userKey":null,"passwordKey":null}` | Specify email user configuration through an existing secret |
+| email.existingSecret.name | string | `nil` | The secret name containing the email user configuration. **required** if any one of `email.existingSecret.\*Key` are set |
+| email.existingSecret.userKey | string | `nil` | Fetch from secret instead of setting `email.user` |
+| email.existingSecret.passwordKey | string | `nil` | Fetch from secret instead of setting `email.password` |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/biru-scop/tenzu-back","tag":"latest"}` | Image to use for the application see: https://kubernetes.io/docs/concepts/containers/images/ |
 | image.tag | string | `"latest"` | Overrides the image tag |
 | imagePullSecrets | list | `nil` | List of secrets needed to pull an image from a private repository see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |

--- a/charts/tenzu-back/templates/_helpers.tpl
+++ b/charts/tenzu-back/templates/_helpers.tpl
@@ -207,18 +207,20 @@ Create the email env variable
 - name: TENZU_EMAIL__EMAIL_PORT
   value: {{ .Values.email.port | quote }}
 - name: TENZU_EMAIL__EMAIL_HOST_USER
-{{- if Values.email.existingSecret.userKey }}
+{{- if .Values.email.existingSecret.userKey }}
   valueFrom:
-    secretKeyRef {{ required "An email secret name is mandatory if any of `email.existingSecret.\*.Key` are set" .Values.email.existingSecret.name }}
-    key: {{ required "An email passwordKey is mandatory if `email.existingSecret.name` is set" .Values.email.existingSecret.passwordKey }}
+    secretKeyRef:
+      name: {{ required "An email secret name is mandatory if any of `email.existingSecret.\*.Key` are set" .Values.email.existingSecret.name }}
+      key: {{ required "An email userKey is mandatory if `email.existingSecret.name` is set" .Values.email.existingSecret.userKey }}
 {{- else }}
   value: {{ required "An email host user is mandatory" .Values.email.user }}
 {{- end }}
 - name: TENZU_EMAIL__EMAIL_HOST_PASSWORD
-{{- if Values.email.existingSecret.passwordKey }}
+{{- if .Values.email.existingSecret.passwordKey }}
   valueFrom:
-    secretKeyRef {{ required "An email secret name is mandatory if any of `email.existingSecret.\*.Key` are set" .Values.email.existingSecret.name }}
-    key: {{ required "An email passwordKey is mandatory if `email.existingSecret.name` is set" .Values.email.existingSecret.passwordKey }}
+    secretKeyRef:
+      name: {{ required "An email secret name is mandatory if any of `email.existingSecret.\*.Key` are set" .Values.email.existingSecret.name }}
+      key: {{ required "An email passwordKey is mandatory if `email.existingSecret.name` is set" .Values.email.existingSecret.passwordKey }}
 {{- else }}
   value: {{ required "An email host password is mandatory" .Values.email.password }}
 {{- end }}

--- a/charts/tenzu-back/templates/_helpers.tpl
+++ b/charts/tenzu-back/templates/_helpers.tpl
@@ -207,9 +207,21 @@ Create the email env variable
 - name: TENZU_EMAIL__EMAIL_PORT
   value: {{ .Values.email.port | quote }}
 - name: TENZU_EMAIL__EMAIL_HOST_USER
+{{- if Values.email.existingSecret.userKey }}
+  valueFrom:
+    secretKeyRef {{ required "An email secret name is mandatory if any of `email.existingSecret.\*.Key` are set" .Values.email.existingSecret.name }}
+    key: {{ required "An email passwordKey is mandatory if `email.existingSecret.name` is set" .Values.email.existingSecret.passwordKey }}
+{{- else }}
   value: {{ required "An email host user is mandatory" .Values.email.user }}
+{{- end }}
 - name: TENZU_EMAIL__EMAIL_HOST_PASSWORD
+{{- if Values.email.existingSecret.passwordKey }}
+  valueFrom:
+    secretKeyRef {{ required "An email secret name is mandatory if any of `email.existingSecret.\*.Key` are set" .Values.email.existingSecret.name }}
+    key: {{ required "An email passwordKey is mandatory if `email.existingSecret.name` is set" .Values.email.existingSecret.passwordKey }}
+{{- else }}
   value: {{ required "An email host password is mandatory" .Values.email.password }}
+{{- end }}
 - name: TENZU_EMAIL__EMAIL_USE_TLS
   value: {{ .Values.email.tls | quote}}
 - name: TENZU_EMAIL__EMAIL_USE_SSL

--- a/charts/tenzu-back/values.yaml
+++ b/charts/tenzu-back/values.yaml
@@ -59,16 +59,25 @@ email:
   ssl: False
   # -- Used to populate `TENZU_EMAIL__EMAIL_PORT`
   port: 547
-  # -- (string) Used to populate `TENZU_EMAIL__DEFAULT_FROM_EMAIL`
-  defaultFrom:
+  # -- (string) Used to populate `TENZU_SUPPORT_EMAIL`
+  supportEmail:
   # -- (string) Used to populate `TENZU_EMAIL__EMAIL_HOST`
   host:
+  # -- (string) Used to populate `TENZU_EMAIL__DEFAULT_FROM_EMAIL`
+  defaultFrom:
+  # -- Specify s3 configuration through an existing secret
+  existingSecret:
+    # -- (string) The secret name containing the email configuration.
+    # **required** if any one of `email.existingSecret.\*Key` are set
+    name:
+    # -- (string) key to access value in existingSecret, used to populate `TENZU_EMAIL__EMAIL_HOST_USER`
+    userKey:
+    # -- (string) key to access value in existingSecret, used to populate `TENZU_EMAIL__EMAIL_HOST_PASSWORD`
+    passwordKey:
   # -- (string) Used to populate `TENZU_EMAIL__EMAIL_HOST_USER`
   user:
   # -- (string) Used to populate `TENZU_EMAIL__EMAIL_HOST_PASSWORD`
   password:
-  # -- (string) Used to populate `TENZU_SUPPORT_EMAIL`
-  supportEmail:
 
 # -- Image to use for the application
 # see: https://kubernetes.io/docs/concepts/containers/images/

--- a/charts/tenzu-back/values.yaml
+++ b/charts/tenzu-back/values.yaml
@@ -59,12 +59,12 @@ email:
   ssl: False
   # -- Used to populate `TENZU_EMAIL__EMAIL_PORT`
   port: 547
-  # -- (string) Used to populate `TENZU_SUPPORT_EMAIL`
-  supportEmail:
-  # -- (string) Used to populate `TENZU_EMAIL__EMAIL_HOST`
-  host:
   # -- (string) Used to populate `TENZU_EMAIL__DEFAULT_FROM_EMAIL`
   defaultFrom:
+  # -- (string) Used to populate `TENZU_EMAIL__EMAIL_HOST`
+  host:
+  # -- (string) Used to populate `TENZU_SUPPORT_EMAIL`
+  supportEmail:
   # -- Specify s3 configuration through an existing secret
   existingSecret:
     # -- (string) The secret name containing the email configuration.


### PR DESCRIPTION
Following how the `s3.existingSecret` configuration was set, i introduced the option to configure sensitive email information (`user` and `password`) through an existing secret, to allow safe storage of the information when using a gitOps solution (like myself).

- Added `email.existingSecret` section
- Added `email.existingSecret.name` to set the name of the secret containing `user` and `password`
- Added `email.existingSecret.userKey` to provide the key containing `user`
- Added `email.existingSecret.passwordKey` to provide the key containing `password`
- Bumped minor chart version to `3.2.0`
- Updated docs to reflect this new options

Let me know if you need any other changes before approval